### PR TITLE
fix: yorkie Client 생성 인수  환경변수 대신 문자열로 수정

### DIFF
--- a/src/pages/IDEPage/CodeEditor/CodeEditor.tsx
+++ b/src/pages/IDEPage/CodeEditor/CodeEditor.tsx
@@ -41,7 +41,7 @@ const CodeEditor = ({
 
   const initializeYorkieEditor = useCallback(async () => {
     // 1. 클라이언트 생성 및 활성화
-    const client = new yorkie.Client(import.meta.env.VITE_YORKIE_API_ADDR, {
+    const client = new yorkie.Client('https://api.yorkie.dev', {
       apiKey: import.meta.env.VITE_YORKIE_API_KEY,
     })
 


### PR DESCRIPTION
## 📄 PR 내용
yorkie Client 생성 인수  환경변수 대신 문자열로 수정

## 관련 이슈
#60 
