### PR TITLE
Feat/#27 로그인 기능 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from 'react-router-dom'
 import LandingPage from './pages/LandingPage/LandingPage'
 import LoginPage from './pages/LoginPage/LoginPage'
 import SignUpPage from './pages/SignUpPage/SignUpPage'
+import OauthLoginHandler from './pages/LoginPage/OauthLoginHandler'
 import ContainerPage from './pages/ContainerPage/ContainerPage'
 import ContainerList from './pages/ContainerPage/ContainerList'
 import IDEPage from './pages/IDEPage/IDEPage'
@@ -12,6 +13,7 @@ function App() {
       <Route path="/" element={<LandingPage />} />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/signup" element={<SignUpPage />} />
+      <Route path="/oauth-login-handler" element={<OauthLoginHandler />} />
       <Route path="/container" element={<ContainerPage />}>
         <Route index element={<Navigate to="my" />} />
         <Route path="my" element={<ContainerList category="내 컨테이너" />} />

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -9,34 +9,22 @@ interface LoginFormFields {
   password: string;
 }
 
-const setCookie = (name: string, value: string, days: number): void => {
-  const date = new Date();
-  date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-  const expires = `expires=${date.toUTCString()}`;
-  document.cookie = `${name}=${value};${expires};path=/`;
-}
-
 const LoginPage: React.FC = () => {
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm<LoginFormFields>();
+
   const navigate = useNavigate();
 
   const onSubmit: SubmitHandler<LoginFormFields> = async (data) => {
     try {
       const response = await API.post('/api/auth/login', data);
-      
-      const accessToken = await response.headers['Authorization']?.split(' ')[1]; // 액세스 토큰 추출
-      const refreshToken = await response.headers['Set-Cookie']?.split(';')[0].split('=')[1]; // 리프레시 토큰 추출
-
-      if (accessToken && refreshToken) {
-        setCookie('accessToken', accessToken, 1); // 액세스 토큰 쿠키를 1일간 유지
-        setCookie('refreshToken', refreshToken, 10); // 리프레시 토큰 쿠키를 10일간 유지
+      if (response.status === 200) {
+        // TODO: rtk -> id, nickname
+        alert('로그인 성공');
         navigate('/container/my');
-      } else {
-        console.error('토큰을 받지 못했습니다.');
       }
     } catch (error: unknown) {
       if (typeof error === 'object' && error !== null && 'message' in error) {
@@ -89,7 +77,7 @@ const LoginPage: React.FC = () => {
             </AbsoluteCenter>
           </Box>
           <Flex flexDir='column' w='full' gap={3} >
-            <a href='/api/oauth2/authorization/kakao' >
+            <a href='/api/oauth2/authorization/kakao'>
               <Button bg='yellow.300' _hover={{ bg: 'yellow.400' }} w='full'>카카오계정으로 로그인</Button>
             </a>
             <a href='/api/oauth2/authorization/naver'>

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -29,7 +29,7 @@ const LoginPage: React.FC = () => {
       const response = await API.post('/api/auth/login', data);
       
       const accessToken = await response.headers['Authorization']?.split(' ')[1]; // 액세스 토큰 추출
-      const refreshToken = await response.headers['Set-Cookie'].split(';')[0].split('=')[1]; // 리프레시 토큰 추출
+      const refreshToken = await response.headers['Set-Cookie']?.split(';')[0].split('=')[1]; // 리프레시 토큰 추출
 
       if (accessToken && refreshToken) {
         setCookie('accessToken', accessToken, 1); // 액세스 토큰 쿠키를 1일간 유지

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -22,7 +22,7 @@ const LoginPage: React.FC = () => {
     try {
       const response = await API.post('/api/auth/login', data);
       if (response.status === 200) {
-        // TODO: rtk -> id, nickname
+        // TODO: rtk -> userInfo(username, nickname) 저장
         alert('로그인 성공');
         navigate('/container/my');
       }

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -9,21 +9,12 @@ interface LoginFormFields {
   password: string;
 }
 
-// 쿠키 설정 함수
 const setCookie = (name: string, value: string, days: number): void => {
   const date = new Date();
   date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
   const expires = `expires=${date.toUTCString()}`;
   document.cookie = `${name}=${value};${expires};path=/`;
-};
-
-// 쿠키 가져오는 함수
-const getCookie = (name: string): string | null => {
-  const value = `; ${document.cookie}`;
-  const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop()?.split(';').shift() || null;
-  return null;
-};
+}
 
 const LoginPage: React.FC = () => {
   const {
@@ -36,18 +27,13 @@ const LoginPage: React.FC = () => {
   const onSubmit: SubmitHandler<LoginFormFields> = async (data) => {
     try {
       const response = await API.post('/api/auth/login', data);
-
-      // 응답 헤더에서 액세스 토큰을 추출
-      const authHeader = response.headers['Authorization'];
-      const accessToken = authHeader ? authHeader.split(' ')[1] : null;
-
-      // 응답 쿠키에서 리프레시 토큰을 추출
-      const refreshToken = getCookie('Refresh-Token');
+      
+      const accessToken = await response.headers['Authorization']?.split(' ')[1]; // 액세스 토큰 추출
+      const refreshToken = await response.headers['Set-Cookie'].split(';')[0].split('=')[1]; // 리프레시 토큰 추출
 
       if (accessToken && refreshToken) {
-        setCookie('accessToken', accessToken, 1); // 액세스 토큰을 쿠키에 1일간 저장
-        setCookie('refreshToken', refreshToken, 10); // 리프레시 토큰을 쿠키에 10일간 저장
-        console.log('토큰 저장 완료:', accessToken, refreshToken);
+        setCookie('accessToken', accessToken, 1); // 액세스 토큰 쿠키를 1일간 유지
+        setCookie('refreshToken', refreshToken, 10); // 리프레시 토큰 쿠키를 10일간 유지
         navigate('/container/my');
       } else {
         console.error('토큰을 받지 못했습니다.');

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -38,7 +38,7 @@ const LoginPage: React.FC = () => {
       const response = await API.post('/api/auth/login', data);
 
       // 응답 헤더에서 액세스 토큰을 추출
-      const authHeader = response.headers['authorization'];
+      const authHeader = response.headers['Authorization'];
       const accessToken = authHeader ? authHeader.split(' ')[1] : null;
 
       // 응답 쿠키에서 리프레시 토큰을 추출
@@ -103,15 +103,15 @@ const LoginPage: React.FC = () => {
             </AbsoluteCenter>
           </Box>
           <Flex flexDir='column' w='full' gap={3} >
-            <Link to='/oauth2/authorization/kakao' >
+            <a href='/api/oauth2/authorization/kakao' >
               <Button bg='yellow.300' _hover={{ bg: 'yellow.400' }} w='full'>카카오계정으로 로그인</Button>
-            </Link>
-            <Link to='/oauth2/authorization/naver'>
+            </a>
+            <a href='/api/oauth2/authorization/naver'>
               <Button bg='green.400' color='white' _hover={{ bg: 'green.500' }} w='full'>네이버로 로그인</Button>
-            </Link>
-            <Link to='/oauth2/authorization/google'>
+            </a>
+            <a href='/api/oauth2/authorization/google'>
               <Button colorScheme='gray' w='full'>구글로 로그인</Button>
-            </Link>
+            </a>
           </Flex>
         </Flex>
       </Flex>

--- a/src/pages/LoginPage/OauthLoginHandler.tsx
+++ b/src/pages/LoginPage/OauthLoginHandler.tsx
@@ -1,0 +1,29 @@
+import { Flex, Text } from "@chakra-ui/react"
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+const OauthLoginHandler: React.FC = () => {
+    const navigate = useNavigate();
+    const params = new URLSearchParams(location.search);
+    
+    useEffect(() => {
+        if (params.get('message') === 'success') {
+            alert('로그인 성공');
+            navigate('/container/my');
+        } else if (params.get('message') === 'fail') {
+            alert('로그인에 실패했습니다.');
+            navigate('/login');
+        } else {
+            alert('요청이 잘못되었습니다.');
+            navigate('/login');
+        }
+    }, [params, navigate]);
+
+    return (
+        <Flex align='center' justify='center' h='full'>
+            <Text>로그인 중...</Text>
+        </Flex>
+    )
+}
+
+export default OauthLoginHandler;


### PR DESCRIPTION
## 📄 PR 내용
로그인 기능 수정
- `jwt token(accessToken, refreshToken)`을 쿠키에 저장하는 로직 삭제
- `"/oauth-login-handler"` 라우트 추가 및 페이지 구현

## 리뷰 시 참고해야 할 사항
`LoginPage.tsx(:25)` response.status 값이 200으로 로그인 성공했을 경우, userInfo 저장 관련 TODO 주석 작성해뒀습니다.

## 관련 이슈
#27 #41 
